### PR TITLE
Move button tokens from foundations to component

### DIFF
--- a/src/Button/Tokens/tokens.ts
+++ b/src/Button/Tokens/tokens.ts
@@ -1,0 +1,158 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  primary: {
+    content: {
+      color: {
+        regular: inube.palette.blue.B400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.blue.B300,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.blue.B400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.blue.B300,
+      },
+    },
+    contrast: {
+      appearance: "light",
+    },
+  },
+  success: {
+    content: {
+      color: {
+        regular: inube.palette.green.G400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.green.G300,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.green.G400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.green.G300,
+      },
+    },
+    contrast: {
+      appearance: "light",
+    },
+  },
+  warning: {
+    content: {
+      color: {
+        regular: inube.palette.yellow.Y400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.yellow.Y300,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.yellow.Y400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.yellow.Y300,
+      },
+    },
+    contrast: {
+      appearance: "dark",
+    },
+  },
+  danger: {
+    content: {
+      color: {
+        regular: inube.palette.red.R400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.red.R300,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.red.R400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.red.R300,
+      },
+    },
+    contrast: {
+      appearance: "light",
+    },
+  },
+  help: {
+    content: {
+      color: {
+        regular: inube.palette.purple.P400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.purple.P300,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.purple.P400,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.purple.P300,
+      },
+    },
+    contrast: {
+      appearance: "light",
+    },
+  },
+  dark: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N500,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.neutral.N900,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N500,
+      },
+    },
+    contrast: {
+      appearance: "light",
+    },
+  },
+  gray: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N20,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N30,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.neutral.N200,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N90,
+      },
+    },
+    contrast: {
+      appearance: "gray",
+    },
+  },
+  light: {
+    content: {
+      color: {
+        regular: inube.palette.neutral.N20,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+    border: {
+      color: {
+        regular: inube.palette.neutral.N20,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+    contrast: {
+      appearance: "dark",
+    },
+  },
+};
+
+export { tokens };

--- a/src/Button/index.tsx
+++ b/src/Button/index.tsx
@@ -2,7 +2,6 @@ import { Icon } from "@inubekit/icon";
 import { Text } from "@inubekit/text";
 import { Spinner } from "@inubekit/spinner";
 import { Stack } from "@inubekit/stack";
-import { inube } from "@inubekit/foundations";
 import {
   IButtonAppearance,
   IButtonType,
@@ -14,6 +13,7 @@ import { StyledButton, StyledLink } from "./styles";
 import { useState } from "react";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
+import { tokens } from "./Tokens/tokens";
 
 interface IButton {
   children?: React.ReactNode;
@@ -61,10 +61,10 @@ const ButtonStructure = (props: IButton) => {
     parentHover = false,
   } = props;
 
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { button: typeof tokens };
   const externalComponentAppearance = (appearance: IButtonAppearance) => {
     return (theme?.button?.[appearance]?.contrast?.appearance ||
-      inube.button[appearance].contrast.appearance) as IButtonAppearance;
+      tokens[appearance].contrast.appearance) as IButtonAppearance;
   };
 
   const [isHovered, setIsHovered] = useState(false);

--- a/src/Button/styles.js
+++ b/src/Button/styles.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledButton = styled.button`
   box-sizing: border-box;
@@ -27,17 +27,17 @@ const StyledButton = styled.button`
       if ($disabled) {
         return (
           theme?.button?.[$appearance].content?.color?.disabled ||
-          inube.button[$appearance].content.color.disabled
+          tokens[$appearance].content.color.disabled
         );
       }
       if ($parentHover)
         return (
           theme?.button?.[$appearance].content?.color?.hover ||
-          inube.button[$appearance].content.color.hover
+          tokens[$appearance].content.color.hover
         );
       return (
         theme?.button?.[$appearance].content?.color?.regular ||
-        inube.button[$appearance].content.color.regular
+        tokens[$appearance].content.color.regular
       );
     }
     return "transparent";
@@ -60,13 +60,13 @@ const StyledButton = styled.button`
       }
       return (
         theme?.button?.[$appearance].border?.color?.disabled ||
-        inube.button[$appearance].border.color.disabled
+        tokens[$appearance].border.color.disabled
       );
     }
     if ($parentHover && $variant !== "none")
       return (
         theme?.button?.[$appearance].border?.color?.hover ||
-        inube.button[$appearance].border.color.hover
+        tokens[$appearance].border.color.hover
       );
     if ($variant === "none") {
       return "transparent";
@@ -74,7 +74,7 @@ const StyledButton = styled.button`
 
     return (
       theme?.button?.[$appearance].border?.color?.regular ||
-      inube.button[$appearance].border.color.regular
+      tokens[$appearance].border.color.regular
     );
   }};
 
@@ -104,7 +104,7 @@ const StyledButton = styled.button`
         }
         return (
           theme?.button?.[$appearance].border?.color?.hover ||
-          inube.button[$appearance].border.color.hover
+          tokens[$appearance].border.color.hover
         );
       }
     }};
@@ -119,7 +119,7 @@ const StyledButton = styled.button`
       if (!$disabled && $cursorHover && $variant === "filled") {
         return (
           theme?.button?.[$appearance].content?.color?.hover ||
-          inube.button[$appearance].content.color.hover
+          tokens[$appearance].content.color.hover
         );
       }
       if (!$disabled && $cursorHover && $variant === "none") {


### PR DESCRIPTION
This PR moves the button tokens from the foundations folder to the component folder, ensuring that all necessary imports have been updated to reflect the new structure. Components have been verified to reference the correct token paths, which enhances the codebase's organization, maintainability, and clarity.